### PR TITLE
bugfix

### DIFF
--- a/app/src/main/java/empty/sahha/android/MainActivity.kt
+++ b/app/src/main/java/empty/sahha/android/MainActivity.kt
@@ -197,7 +197,7 @@ class MainActivity : ComponentActivity() {
                                 Button(onClick = {
                                     Sahha.enableSensors(
                                         this@MainActivity,
-                                        setOf(SahhaSensor.sleep)
+                                        setOf(SahhaSensor.sleep, SahhaSensor.device_lock)
                                     ) { error, status ->
                                         permissionStatus =
                                             "${status.name}${error?.let { "\n$it" } ?: ""}"

--- a/sahha-android/src/main/java/sdk/sahha/android/framework/service/DataCollectionService.kt
+++ b/sahha-android/src/main/java/sdk/sahha/android/framework/service/DataCollectionService.kt
@@ -56,7 +56,7 @@ internal class DataCollectionService : Service() {
                 SahhaReconfigure(this@DataCollectionService.applicationContext)
                 startForegroundNotification()
 
-                config = Sahha.di.configurationDao.getConfig() ?: return@launch
+                config = Sahha.di.sahhaConfigRepo.getConfig() ?: return@launch
 
                 startTimeZoneChangedReceiver()
                 startDataCollectors(this@DataCollectionService)
@@ -111,6 +111,11 @@ internal class DataCollectionService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         checkAndKillService(intent)
         checkAndRestartService(intent)
+        scope.launch {
+            SahhaReconfigure(this@DataCollectionService)
+            config = Sahha.di.sahhaConfigRepo.getConfig() ?: return@launch
+            checkAndStartCollectingScreenLockData()
+        }
         return START_STICKY
     }
 


### PR DESCRIPTION
- if the permission flow is staggered and the `device_lock` is not requested initially (e.g. steps first page -> then device_locks on another page)
- the phone locks do not get recorded