### PR TITLE
Hotfix for steps or sleep being unavailable

### DIFF
--- a/sahha-android/src/main/java/sdk/sahha/android/domain/interaction/PermissionInteractionManager.kt
+++ b/sahha-android/src/main/java/sdk/sahha/android/domain/interaction/PermissionInteractionManager.kt
@@ -1,6 +1,7 @@
 package sdk.sahha.android.domain.interaction
 
 import android.content.Context
+import android.os.Build
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -64,10 +65,13 @@ internal class PermissionInteractionManager @Inject constructor(
                 return@launch
             }
 
+            val isAndroid9 = Build.VERSION.SDK_INT == Build.VERSION_CODES.P
             val containsStepsOrSleep =
                 sensors.contains(SahhaSensor.step_count) || sensors.contains(SahhaSensor.sleep)
             val nativeStatus =
-                if (containsStepsOrSleep) awaitNativeSensorRequest(context) else SahhaSensorStatus.enabled
+                if (isAndroid9) SahhaSensorStatus.enabled
+                else if (containsStepsOrSleep) awaitNativeSensorRequest(context)
+                else SahhaSensorStatus.enabled
             val healthConnectStatus = awaitHealthConnectSensorRequest(context, nativeStatus)
 
             val status = processStatuses(nativeStatus, healthConnectStatus.second)
@@ -304,10 +308,13 @@ internal class PermissionInteractionManager @Inject constructor(
                 return@launch
             }
 
+            val isAndroid9 = Build.VERSION.SDK_INT == Build.VERSION_CODES.P
             val containsStepsOrSleep =
                 sensors.contains(SahhaSensor.step_count) || sensors.contains(SahhaSensor.sleep)
             val nativeStatus =
-                if (containsStepsOrSleep) awaitNativeSensorStatus(context) else SahhaSensorStatus.enabled
+                if(isAndroid9) SahhaSensorStatus.enabled
+                else if (containsStepsOrSleep) awaitNativeSensorStatus(context)
+                else SahhaSensorStatus.enabled
 
             if (manager.shouldUseHealthConnect())
                 getHealthConnectSensorStatus(context, sensors) { error, status ->

--- a/sahha-android/src/main/java/sdk/sahha/android/domain/interaction/PermissionInteractionManager.kt
+++ b/sahha-android/src/main/java/sdk/sahha/android/domain/interaction/PermissionInteractionManager.kt
@@ -65,11 +65,11 @@ internal class PermissionInteractionManager @Inject constructor(
                 return@launch
             }
 
-            val isAndroid9 = Build.VERSION.SDK_INT == Build.VERSION_CODES.P
+            val isAndroid8 = Build.VERSION.SDK_INT <= Build.VERSION_CODES.P
             val containsStepsOrSleep =
                 sensors.contains(SahhaSensor.step_count) || sensors.contains(SahhaSensor.sleep)
             val nativeStatus =
-                if (isAndroid9) SahhaSensorStatus.enabled
+                if (isAndroid8) SahhaSensorStatus.enabled
                 else if (containsStepsOrSleep) awaitNativeSensorRequest(context)
                 else SahhaSensorStatus.enabled
             val healthConnectStatus = awaitHealthConnectSensorRequest(context, nativeStatus)
@@ -308,11 +308,11 @@ internal class PermissionInteractionManager @Inject constructor(
                 return@launch
             }
 
-            val isAndroid9 = Build.VERSION.SDK_INT == Build.VERSION_CODES.P
+            val isAndroid8 = Build.VERSION.SDK_INT <= Build.VERSION_CODES.P
             val containsStepsOrSleep =
                 sensors.contains(SahhaSensor.step_count) || sensors.contains(SahhaSensor.sleep)
             val nativeStatus =
-                if(isAndroid9) SahhaSensorStatus.enabled
+                if(isAndroid8) SahhaSensorStatus.enabled
                 else if (containsStepsOrSleep) awaitNativeSensorStatus(context)
                 else SahhaSensorStatus.enabled
 

--- a/sahha-android/src/main/java/sdk/sahha/android/domain/interaction/PermissionInteractionManager.kt
+++ b/sahha-android/src/main/java/sdk/sahha/android/domain/interaction/PermissionInteractionManager.kt
@@ -35,6 +35,8 @@ internal class PermissionInteractionManager @Inject constructor(
     @DefaultScope private val defaultScope: CoroutineScope,
     @MainScope private val mainScope: CoroutineScope,
 ) {
+    private val isAndroid8 = Build.VERSION.SDK_INT <= Build.VERSION_CODES.P
+
     fun openAppSettings(context: Context) {
         openAppSettingsUseCase(context)
     }
@@ -65,7 +67,6 @@ internal class PermissionInteractionManager @Inject constructor(
                 return@launch
             }
 
-            val isAndroid8 = Build.VERSION.SDK_INT <= Build.VERSION_CODES.P
             val containsStepsOrSleep =
                 sensors.contains(SahhaSensor.step_count) || sensors.contains(SahhaSensor.sleep)
             val nativeStatus =
@@ -308,7 +309,6 @@ internal class PermissionInteractionManager @Inject constructor(
                 return@launch
             }
 
-            val isAndroid8 = Build.VERSION.SDK_INT <= Build.VERSION_CODES.P
             val containsStepsOrSleep =
                 sensors.contains(SahhaSensor.step_count) || sensors.contains(SahhaSensor.sleep)
             val nativeStatus =


### PR DESCRIPTION
The Activity Recognition permission being unavailable in Android 9 was blocking the availability of Health Connect's steps and sleep data