### PR TITLE
add device id when sending deviceInformation

### DIFF
--- a/sahha-android/src/main/java/sdk/sahha/android/data/manager/IdManagerImpl.kt
+++ b/sahha-android/src/main/java/sdk/sahha/android/data/manager/IdManagerImpl.kt
@@ -1,0 +1,19 @@
+package sdk.sahha.android.data.manager
+
+import android.content.SharedPreferences
+import sdk.sahha.android.domain.manager.IdManager
+import javax.inject.Inject
+
+const val DEVICE_ID = "device_id"
+
+internal class IdManagerImpl @Inject constructor(
+    private val sharedPreferences: SharedPreferences
+) : IdManager {
+    override fun getDeviceId(): String? {
+        return sharedPreferences.getString(DEVICE_ID, null)
+    }
+
+    override fun saveDeviceId(id: String) {
+        sharedPreferences.edit().putString(DEVICE_ID, id).apply()
+    }
+}

--- a/sahha-android/src/main/java/sdk/sahha/android/di/AppModule.kt
+++ b/sahha-android/src/main/java/sdk/sahha/android/di/AppModule.kt
@@ -40,6 +40,7 @@ import sdk.sahha.android.data.local.dao.ManualPermissionsDao
 import sdk.sahha.android.data.local.dao.MovementDao
 import sdk.sahha.android.data.local.dao.SecurityDao
 import sdk.sahha.android.data.local.dao.SleepDao
+import sdk.sahha.android.data.manager.IdManagerImpl
 import sdk.sahha.android.data.manager.PermissionManagerImpl
 import sdk.sahha.android.data.manager.PostChunkManagerImpl
 import sdk.sahha.android.data.provider.PermissionActionProviderImpl
@@ -56,6 +57,7 @@ import sdk.sahha.android.data.repository.SahhaConfigRepoImpl
 import sdk.sahha.android.data.repository.SensorRepoImpl
 import sdk.sahha.android.data.repository.SleepRepoImpl
 import sdk.sahha.android.data.repository.UserDataRepoImpl
+import sdk.sahha.android.domain.manager.IdManager
 import sdk.sahha.android.domain.manager.PermissionManager
 import sdk.sahha.android.domain.manager.PostChunkManager
 import sdk.sahha.android.domain.manager.ReceiverManager
@@ -149,15 +151,25 @@ internal class AppModule(private val sahhaEnvironment: Enum<SahhaEnvironment>) {
 
     @Singleton
     @Provides
+    fun provideIdManager(
+        sharedPreferences: SharedPreferences
+    ): IdManager {
+        return IdManagerImpl(sharedPreferences)
+    }
+
+    @Singleton
+    @Provides
     fun provideDeviceInfoRepo(
         configDao: ConfigurationDao,
         api: SahhaApi,
-        sahhaErrorLogger: SahhaErrorLogger
+        sahhaErrorLogger: SahhaErrorLogger,
+        idManager: IdManager,
     ): DeviceInfoRepo {
         return DeviceInfoRepoImpl(
             configDao,
             api,
-            sahhaErrorLogger
+            sahhaErrorLogger,
+            idManager
         )
     }
 

--- a/sahha-android/src/main/java/sdk/sahha/android/domain/interaction/UserDataInteractionManager.kt
+++ b/sahha-android/src/main/java/sdk/sahha/android/domain/interaction/UserDataInteractionManager.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.runBlocking
 import sdk.sahha.android.common.SahhaErrors
 import sdk.sahha.android.di.IoScope
 import sdk.sahha.android.di.MainScope
+import sdk.sahha.android.domain.manager.IdManager
 import sdk.sahha.android.domain.model.config.SahhaConfiguration
 import sdk.sahha.android.domain.model.device_info.DeviceInformation
 import sdk.sahha.android.domain.repository.AuthRepo
@@ -33,6 +34,7 @@ internal class UserDataInteractionManager @Inject constructor(
     private val getScoresUseCase: GetScoresUseCase,
     private val getDemographicUseCase: GetDemographicUseCase,
     private val postDemographicUseCase: PostDemographicUseCase,
+    private val idManager: IdManager,
 ) {
     fun getScores(
         types: Set<SahhaScoreType>,

--- a/sahha-android/src/main/java/sdk/sahha/android/domain/manager/IdManager.kt
+++ b/sahha-android/src/main/java/sdk/sahha/android/domain/manager/IdManager.kt
@@ -1,0 +1,6 @@
+package sdk.sahha.android.domain.manager
+
+internal interface IdManager {
+    fun getDeviceId(): String?
+    fun saveDeviceId(id: String)
+}

--- a/sahha-android/src/main/java/sdk/sahha/android/domain/model/device_info/DeviceInformation.kt
+++ b/sahha-android/src/main/java/sdk/sahha/android/domain/model/device_info/DeviceInformation.kt
@@ -23,8 +23,11 @@ internal data class DeviceInformation(
     val appVersion: String? = null
 )
 
-internal fun DeviceInformation.toDeviceInformationSendDto(): DeviceInformationDto {
+internal fun DeviceInformation.toDeviceInformationSendDto(
+    deviceId: String
+): DeviceInformationDto {
     return DeviceInformationDto(
+        deviceId,
         sdkId,
         sdkVersion,
         appId,

--- a/sahha-android/src/main/java/sdk/sahha/android/domain/model/dto/send/DeviceInformationDto.kt
+++ b/sahha-android/src/main/java/sdk/sahha/android/domain/model/dto/send/DeviceInformationDto.kt
@@ -4,6 +4,7 @@ import androidx.annotation.Keep
 
 @Keep
 internal data class DeviceInformationDto(
+    val deviceId: String,
     val sdkId: String,
     val sdkVersion: String,
     val appId: String,

--- a/sahha-android/src/main/java/sdk/sahha/android/source/SahhaConverterUtility.kt
+++ b/sahha-android/src/main/java/sdk/sahha/android/source/SahhaConverterUtility.kt
@@ -13,9 +13,6 @@ import okhttp3.ResponseBody
 import okio.Buffer
 import org.json.JSONArray
 import org.json.JSONObject
-import sdk.sahha.android.domain.model.device_info.DeviceInformation
-import sdk.sahha.android.domain.model.device_info.toDeviceInformationSendDto
-import sdk.sahha.android.domain.model.dto.send.DeviceInformationDto
 import sdk.sahha.android.domain.model.error_log.SahhaResponseError
 import sdk.sahha.android.domain.model.error_log.SahhaResponseErrorItem
 import java.time.Instant
@@ -137,10 +134,6 @@ object SahhaConverterUtility {
         } catch (e: Exception) {
             null
         }
-    }
-
-    internal fun deviceInfoToDeviceInfoSendDto(deviceInfo: DeviceInformation): DeviceInformationDto {
-        return deviceInfo.toDeviceInformationSendDto()
     }
 
     fun stringToDrawableResource(context: Context, iconString: String?): Int? {


### PR DESCRIPTION
- check and see if a device id already exists, generate a new uuid if it does not and store it
- always use stored device id, until indirectly wiped e.g. app uninstall